### PR TITLE
Add support for PHPUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "tightenco/collect": "^5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^7.0",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.1"
     },
     "autoload": {

--- a/tests/MovieGetTest.php
+++ b/tests/MovieGetTest.php
@@ -17,18 +17,18 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('int', $movie->getId());
+        $this->assertIsInt($movie->getId());
     }
 
     /**
      * @throws \Exception
      */
-    public function testCanGetUrl()
+    public function testCanGetUrl(): void
     {
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getUrl());
+        $this->assertIsString($movie->getUrl());
     }
 
     /**
@@ -39,7 +39,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getImdbCode());
+        $this->assertIsString($movie->getImdbCode());
     }
 
     /**
@@ -50,7 +50,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getTitle());
+        $this->assertIsString($movie->getTitle());
     }
 
     /**
@@ -61,7 +61,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getTitleEnglish());
+        $this->assertIsString($movie->getTitleEnglish());
     }
 
     /**
@@ -72,7 +72,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getTitleLong());
+        $this->assertIsString($movie->getTitleLong());
     }
 
     /**
@@ -83,7 +83,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getSlug());
+        $this->assertIsString($movie->getSlug());
     }
 
     /**
@@ -94,7 +94,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('int', $movie->getYear());
+        $this->assertIsInt($movie->getYear());
     }
 
     /**
@@ -105,7 +105,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('float', $movie->getRating());
+        $this->assertIsFloat($movie->getRating());
     }
 
     /**
@@ -116,7 +116,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('int', $movie->getRuntime());
+        $this->assertIsInt($movie->getRuntime());
     }
 
     /**
@@ -128,7 +128,7 @@ class MovieGetTest extends TestCase
             'movie_id' => 10,
         ]);
         $this->assertTrue($movie->getGenres()->isNotEmpty());
-        $this->assertInternalType('string', $movie->getGenres()->first());
+        $this->assertIsString($movie->getGenres()->first());
     }
 
     /**
@@ -139,7 +139,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('int', $movie->getDownloadCount());
+        $this->assertIsInt($movie->getDownloadCount());
     }
 
     /**
@@ -150,7 +150,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('int', $movie->getLikeCount());
+        $this->assertIsInt($movie->getLikeCount());
     }
 
     /**
@@ -161,7 +161,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::list([
             'movie_id' => 10,
         ])->first();
-        $this->assertInternalType('string', $movie->getSummary());
+        $this->assertIsString($movie->getSummary());
     }
 
     /**
@@ -172,7 +172,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::list([
             'movie_id' => 10,
         ])->first();
-        $this->assertInternalType('string', $movie->getDescriptionFull());
+        $this->assertIsString($movie->getDescriptionFull());
     }
 
     /**
@@ -183,7 +183,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::list([
             'movie_id' => 10,
         ])->first();
-        $this->assertInternalType('string', $movie->getSynopsis());
+        $this->assertIsString($movie->getSynopsis());
     }
 
     /**
@@ -194,7 +194,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getYtTrailerCode());
+        $this->assertIsString($movie->getYtTrailerCode());
     }
 
     /**
@@ -205,7 +205,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getLanguage());
+        $this->assertIsString($movie->getLanguage());
     }
 
     /**
@@ -216,7 +216,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getMpaRating());
+        $this->assertIsString($movie->getMpaRating());
     }
 
     /**
@@ -227,7 +227,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getBackgroundImage());
+        $this->assertIsString($movie->getBackgroundImage());
     }
 
     /**
@@ -238,7 +238,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getBackgroundImageOriginal());
+        $this->assertIsString($movie->getBackgroundImageOriginal());
     }
 
     /**
@@ -249,7 +249,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getSmallCoverImage());
+        $this->assertIsString($movie->getSmallCoverImage());
     }
 
     /**
@@ -260,7 +260,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getMediumCoverImage());
+        $this->assertIsString($movie->getMediumCoverImage());
     }
 
     /**
@@ -271,7 +271,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getLargeCoverImage());
+        $this->assertIsString($movie->getLargeCoverImage());
     }
 
     /**
@@ -282,7 +282,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::list([
             'movie_id' => 10,
         ])->first();
-        $this->assertInternalType('string', $movie->getState());
+        $this->assertIsString($movie->getState());
     }
 
     /**
@@ -294,7 +294,7 @@ class MovieGetTest extends TestCase
             'movie_id' => 10,
         ]);
         $this->assertTrue($movie->getTorrents()->isNotEmpty());
-        $this->assertInternalType('string', $movie->getTorrents()->first()->getUrl());
+        $this->assertIsString($movie->getTorrents()->first()->getUrl());
     }
 
     /**
@@ -305,7 +305,7 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('string', $movie->getDateUploaded());
+        $this->assertIsString($movie->getDateUploaded());
     }
 
     /**
@@ -316,6 +316,6 @@ class MovieGetTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertInternalType('int', $movie->getDateUploadedUnix());
+        $this->assertIsInt($movie->getDateUploadedUnix());
     }
 }

--- a/tests/MoviesDetailsTest.php
+++ b/tests/MoviesDetailsTest.php
@@ -17,7 +17,7 @@ class MoviesDetailsTest extends TestCase
         $movie = Movies::details([
             'movie_id' => 10,
         ]);
-        $this->assertTrue($movie instanceof Movie);
+        $this->assertInstanceOf(Movie::class, $movie);
     }
 
     /**
@@ -26,10 +26,10 @@ class MoviesDetailsTest extends TestCase
     public function testCanRetrieveMovieWithImages()
     {
         $movie = Movies::details([
-            'movie_id'    => 10,
+            'movie_id' => 10,
             'with_images' => true,
         ]);
-        $this->assertTrue($movie instanceof Movie);
+        $this->assertInstanceOf(Movie::class, $movie);
     }
 
     /**
@@ -38,10 +38,10 @@ class MoviesDetailsTest extends TestCase
     public function testCanRetrieveMovieWithCast()
     {
         $movie = Movies::details([
-            'movie_id'  => 10,
+            'movie_id' => 10,
             'with_cast' => true,
         ]);
-        $this->assertTrue($movie instanceof Movie);
+        $this->assertInstanceOf(Movie::class, $movie);
     }
 
     /**

--- a/tests/TorrentGetTest.php
+++ b/tests/TorrentGetTest.php
@@ -17,7 +17,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('string', $torrent->getUrl());
+        $this->assertIsString($torrent->getUrl());
     }
 
     /**
@@ -28,7 +28,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('string', $torrent->getHash());
+        $this->assertIsString($torrent->getHash());
     }
 
     /**
@@ -39,7 +39,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('string', $torrent->getQuality());
+        $this->assertIsString($torrent->getQuality());
     }
 
     /**
@@ -50,7 +50,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('int', $torrent->getSeeds());
+        $this->assertIsInt($torrent->getSeeds());
     }
 
     /**
@@ -61,7 +61,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('int', $torrent->getPeers());
+        $this->assertIsInt($torrent->getPeers());
     }
 
     /**
@@ -72,7 +72,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('string', $torrent->getSize());
+        $this->assertIsString($torrent->getSize());
     }
 
     /**
@@ -83,7 +83,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('int', $torrent->getSizeBytes());
+        $this->assertIsInt($torrent->getSizeBytes());
     }
 
     /**
@@ -94,7 +94,7 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('string', $torrent->getDateUploaded());
+        $this->assertIsString($torrent->getDateUploaded());
     }
 
     /**
@@ -105,6 +105,6 @@ class TorrentGetTest extends TestCase
         $torrent = Movies::details([
             'movie_id' => 10,
         ])->getTorrents()->first();
-        $this->assertInternalType('int', $torrent->getDateUploadedUnix());
+        $this->assertIsInt($torrent->getDateUploadedUnix());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds support for PHPUnit 8 and drops PHPUnit 6 support.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
